### PR TITLE
Allow configuration of plugin update intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ out with the default config (below), and customize Hyperline to your liking.
 
 * The `color` string is used to specify the color of the line itself.
 * The `plugins` array determines which plugins are rendered, and in which order.
-  * Each plugin configuration has an `options` object. This can be used to change
-  the color of the each plugin. Some plugins allow you to choose multiple colors.
+  * Each plugin configuration has an `options` object.
+    * This can be used to change the color of the each plugin.
+    * Some plugins allow you to choose multiple colors.
+    * Some plugins allow you to change the update interval, where relevant. 
   * You can omit the options object to stick with the default options for each plugin.
 * Check out the list of available colors in the [HyperTerm source code](https://github.com/zeit/hyperterm/blob/master/lib/utils/colors.js).
 
@@ -46,13 +48,15 @@ module.exports = {
         {
           name: 'memory',
           options: {
-            color: 'white'
+            color: 'white',
+            updateIntervalMs: 1000
           }
         },
         {
           name: 'uptime',
           options: {
-            color: 'lightYellow'
+            color: 'lightYellow',
+            updateIntervalMs: 60000
           }
         },
         {
@@ -62,14 +66,16 @@ module.exports = {
               high: 'lightRed',
               moderate: 'lightYellow',
               low: 'lightGreen'
-            }
+            },
+            updateIntervalMs: 500
           }
         },
         {
           name: 'network',
           options: {
-            color: 'lightCyan'
-          }
+            color: 'lightCyan',
+            updateIntervalMs: 1000
+          },
         },
         {
           name: 'battery',

--- a/src/lib/plugins/battery.js
+++ b/src/lib/plugins/battery.js
@@ -1,7 +1,6 @@
 import { iconStyles } from '../utils/icons'
-import { colorExists } from '../utils/colors'
 import pluginWrapperFactory from '../core/PluginWrapper'
-
+import { colorExists } from '../utils/colors'
 
 const pluginIcon = (React, state, fillColor) => {
   const calcCharge = percent => {

--- a/src/lib/plugins/cpu.js
+++ b/src/lib/plugins/cpu.js
@@ -56,7 +56,7 @@ export function componentFactory( React, colors ) {
         this.setState({
           cpuAverage: this.calculateCpuUsage()
         })
-      }, 500)
+      }, props.options.updateIntervalMs)
     }
 
     calculateCpuUsage() {
@@ -128,7 +128,7 @@ export function componentFactory( React, colors ) {
 export const validateOptions = (options) => {
   const errors = []
 
-  if (!options.colors) {
+  if (typeof options.colors === 'undefined') {
     errors.push('\'colors\' object is required but missing.')
   } else {
     if (!options.colors.high) {
@@ -150,10 +150,23 @@ export const validateOptions = (options) => {
     }
   }
 
+  if (typeof options.updateIntervalMs === 'undefined') {
+    errors.push('\'updateIntervalMs\' is required but missing.')
+  } else {
+    if (typeof options.updateIntervalMs !== 'number') {
+      errors.push('update interval must be defined as a number.');
+    } else {
+      if (options.updateIntervalMs < 1) {
+        errors.push('update interval must be at least 1ms.');
+      }
+    }
+  }
+
   return errors
 }
 
 export const defaultOptions = {
+  updateIntervalMs: 500,
   colors: {
     high: 'lightRed',
     moderate: 'lightYellow',

--- a/src/lib/plugins/cpu.js
+++ b/src/lib/plugins/cpu.js
@@ -1,8 +1,8 @@
 import os from 'os'
 import { iconStyles } from '../utils/icons'
 import { colorExists } from '../utils/colors'
+import { combineValidators, validateUpdateIntervalMs } from '../utils/validators'
 import pluginWrapperFactory from '../core/PluginWrapper'
-import { validateOptionsWith, validateUpdateIntervalMs } from '../utils/validators'
 
 const pluginIcon = (React, fillColor) => (
   <svg style={iconStyles} xmlns="http://www.w3.org/2000/svg">
@@ -126,40 +126,40 @@ export function componentFactory( React, colors ) {
   }
 }
 
-export const validateOptions = (options) => {
-  return validateOptionsWith(options,
-    [
-      validateUpdateIntervalMs,
-      (options) => {
-        const errors = []
+const validateColors = (options) => {
+  const errors = []
 
-        if (typeof options.colors === 'undefined') {
-          errors.push('\'colors\' object is required but missing.')
-        } else {
-          if (!options.colors.high) {
-            errors.push('\'colors.high\' color string is required but missing.')
-          } else if (!colorExists(options.colors.high)) {
-            errors.push(`invalid color '${options.colors.high}'`)
-          }
+  if (typeof options.colors === 'undefined') {
+    errors.push('\'colors\' object is required but missing.')
+  } else {
+    if (!options.colors.high) {
+      errors.push('\'colors.high\' color string is required but missing.')
+    } else if (!colorExists(options.colors.high)) {
+      errors.push(`invalid color '${options.colors.high}'`)
+    }
 
-          if (!options.colors.moderate) {
-            errors.push('\'colors.moderate\' color string is required but missing.')
-          } else if (!colorExists(options.colors.moderate)) {
-            errors.push(`invalid color '${options.colors.moderate}'`)
-          }
+    if (!options.colors.moderate) {
+      errors.push('\'colors.moderate\' color string is required but missing.')
+    } else if (!colorExists(options.colors.moderate)) {
+      errors.push(`invalid color '${options.colors.moderate}'`)
+    }
 
-          if (!options.colors.low) {
-            errors.push('\'colors.low\' color string is required but missing.')
-          } else if (!colorExists(options.colors.low)) {
-            errors.push(`invalid color '${options.colors.low}'`)
-          }
-        }
+    if (!options.colors.low) {
+      errors.push('\'colors.low\' color string is required but missing.')
+    } else if (!colorExists(options.colors.low)) {
+      errors.push(`invalid color '${options.colors.low}'`)
+    }
+  }
 
-        return errors
-      }
-    ]
-  )
+  return errors
 }
+
+export const validateOptions = combineValidators(
+  [
+    validateUpdateIntervalMs,
+    validateColors
+  ]
+)
 
 export const defaultOptions = {
   updateIntervalMs: 500,

--- a/src/lib/plugins/cpu.js
+++ b/src/lib/plugins/cpu.js
@@ -1,7 +1,8 @@
 import os from 'os'
-import {iconStyles} from '../utils/icons'
-import {colorExists} from '../utils/colors'
+import { iconStyles } from '../utils/icons'
+import { colorExists } from '../utils/colors'
 import pluginWrapperFactory from '../core/PluginWrapper'
+import { validateOptionsWith, validateUpdateIntervalMs } from '../utils/validators'
 
 const pluginIcon = (React, fillColor) => (
   <svg style={iconStyles} xmlns="http://www.w3.org/2000/svg">
@@ -126,43 +127,38 @@ export function componentFactory( React, colors ) {
 }
 
 export const validateOptions = (options) => {
-  const errors = []
+  return validateOptionsWith(options,
+    [
+      validateUpdateIntervalMs,
+      (options) => {
+        const errors = []
 
-  if (typeof options.colors === 'undefined') {
-    errors.push('\'colors\' object is required but missing.')
-  } else {
-    if (!options.colors.high) {
-      errors.push('\'colors.high\' color string is required but missing.')
-    } else if (!colorExists(options.colors.high)) {
-      errors.push(`invalid color '${options.colors.high}'`)
-    }
+        if (typeof options.colors === 'undefined') {
+          errors.push('\'colors\' object is required but missing.')
+        } else {
+          if (!options.colors.high) {
+            errors.push('\'colors.high\' color string is required but missing.')
+          } else if (!colorExists(options.colors.high)) {
+            errors.push(`invalid color '${options.colors.high}'`)
+          }
 
-    if (!options.colors.moderate) {
-      errors.push('\'colors.moderate\' color string is required but missing.')
-    } else if (!colorExists(options.colors.moderate)) {
-      errors.push(`invalid color '${options.colors.moderate}'`)
-    }
+          if (!options.colors.moderate) {
+            errors.push('\'colors.moderate\' color string is required but missing.')
+          } else if (!colorExists(options.colors.moderate)) {
+            errors.push(`invalid color '${options.colors.moderate}'`)
+          }
 
-    if (!options.colors.low) {
-      errors.push('\'colors.low\' color string is required but missing.')
-    } else if (!colorExists(options.colors.low)) {
-      errors.push(`invalid color '${options.colors.low}'`)
-    }
-  }
+          if (!options.colors.low) {
+            errors.push('\'colors.low\' color string is required but missing.')
+          } else if (!colorExists(options.colors.low)) {
+            errors.push(`invalid color '${options.colors.low}'`)
+          }
+        }
 
-  if (typeof options.updateIntervalMs === 'undefined') {
-    errors.push('\'updateIntervalMs\' is required but missing.')
-  } else {
-    if (typeof options.updateIntervalMs !== 'number') {
-      errors.push('update interval must be defined as a number.');
-    } else {
-      if (options.updateIntervalMs < 1) {
-        errors.push('update interval must be at least 1ms.');
+        return errors
       }
-    }
-  }
-
-  return errors
+    ]
+  )
 }
 
 export const defaultOptions = {

--- a/src/lib/plugins/hostname.js
+++ b/src/lib/plugins/hostname.js
@@ -1,7 +1,7 @@
 import os from 'os'
-import { iconStyles } from '../utils/icons'
-import { colorExists } from '../utils/colors'
 import pluginWrapperFactory from '../core/PluginWrapper'
+import { iconStyles } from '../utils/icons'
+import { validateColor } from '../utils/validators'
 
 const pluginIcon = (React, fillColor) => (
   <svg style={iconStyles} xmlns="http://www.w3.org/2000/svg">
@@ -38,17 +38,7 @@ export function componentFactory(React, colors) {
   }
 }
 
-export const validateOptions = (options) => {
-  const errors = []
-
-  if (!options.color) {
-    errors.push('\'color\' color string is required but missing.')
-  } else if (!colorExists(options.color)) {
-    errors.push(`invalid color '${options.color}'`)
-  }
-
-  return errors
-}
+export const validateOptions = validateColor
 
 export const defaultOptions = {
   color: 'lightBlue'

--- a/src/lib/plugins/memory.js
+++ b/src/lib/plugins/memory.js
@@ -1,7 +1,11 @@
 import os from 'os'
-import { iconStyles } from '../utils/icons'
-import { colorExists } from '../utils/colors'
 import pluginWrapperFactory from '../core/PluginWrapper'
+import { iconStyles } from '../utils/icons'
+import {
+  combineValidators,
+  validateUpdateIntervalMs,
+  validateColor
+} from '../utils/validators'
 
 const pluginIcon = (React, fillColor) => (
   <svg style={iconStyles} xmlns="http://www.w3.org/2000/svg">
@@ -47,7 +51,7 @@ export function componentFactory(React, colors) {
         totalMemory: this.getMb(os.totalmem())
       }
 
-      setInterval(() => this.calculateFreeMemory(), 100)
+      setInterval(() => this.calculateFreeMemory(), this.props.options.updateIntervalMs)
     }
 
     getMb(bytes) {
@@ -73,18 +77,12 @@ export function componentFactory(React, colors) {
   }
 }
 
-export const validateOptions = (options) => {
-  const errors = []
-
-  if (!options.color) {
-    errors.push('\'color\' color string is required but missing.')
-  } else if (!colorExists(options.color)) {
-    errors.push(`invalid color '${options.color}'`)
-  }
-
-  return errors
-}
+export const validateOptions = combineValidators([
+  validateUpdateIntervalMs,
+  validateColor
+])
 
 export const defaultOptions = {
+  updateIntervalMs: 1000,
   color: 'white'
 }

--- a/src/lib/plugins/network.js
+++ b/src/lib/plugins/network.js
@@ -1,7 +1,11 @@
 import { networkStats } from 'systeminformation'
-import { iconStyles } from '../utils/icons'
-import { colorExists } from '../utils/colors'
 import pluginWrapperFactory from '../core/PluginWrapper'
+import { iconStyles } from '../utils/icons'
+import {
+  combineValidators,
+  validateUpdateIntervalMs,
+  validateColor
+} from '../utils/validators'
 
 const pluginIcon = (React, fillColor) => (
   <svg style={iconStyles} xmlns="http://www.w3.org/2000/svg">
@@ -30,14 +34,14 @@ export function componentFactory(React, colors) {
 
     constructor(props) {
       super(props)
+
       this.state = {
         download: 0,
         upload: 0
       }
 
       this.getSpeed()
-
-      setInterval(() => this.getSpeed(), 500);
+      setInterval(() => this.getSpeed(), this.props.options.updateIntervalMs);
     }
 
     getSpeed() {
@@ -74,18 +78,12 @@ export function componentFactory(React, colors) {
   }
 }
 
-export const validateOptions = (options) => {
-  const errors = []
-
-  if (!options.color) {
-    errors.push('\'color\' color string is required but missing.')
-  } else if (!colorExists(options.color)) {
-    errors.push(`invalid color '${options.color}'`)
-  }
-
-  return errors
-}
+export const validateOptions = combineValidators([
+  validateUpdateIntervalMs,
+  validateColor
+])
 
 export const defaultOptions = {
+  updateIntervalMs: 1000,
   color: 'lightCyan'
 }

--- a/src/lib/plugins/uptime.js
+++ b/src/lib/plugins/uptime.js
@@ -1,7 +1,11 @@
 import os from 'os'
-import { iconStyles } from '../utils/icons'
 import pluginWrapperFactory from '../core/PluginWrapper'
-import { colorExists } from '../utils/colors'
+import { iconStyles } from '../utils/icons'
+import {
+  combineValidators,
+  validateUpdateIntervalMs,
+  validateColor
+} from '../utils/validators'
 
 const pluginIcon = (React, fillColor) => (
   <svg style={iconStyles} xmlns="http://www.w3.org/2000/svg">
@@ -34,8 +38,7 @@ export function componentFactory(React, colors) {
         uptime: this.getUptime()
       }
 
-      // Recheck every 5 minutes
-      setInterval(() => this.getUptime(), 60000 * 5)
+      setInterval(() => this.getUptime(), this.props.options.updateIntervalMs)
     }
 
     getUptime() {
@@ -58,18 +61,12 @@ export function componentFactory(React, colors) {
   }
 }
 
-export const validateOptions = (options) => {
-  const errors = []
-
-  if (!options.color) {
-    errors.push('\'color\' color string is required but missing.')
-  } else if (!colorExists(options.color)) {
-    errors.push(`invalid color '${options.color}'`)
-  }
-
-  return errors
-}
+export const validateOptions = combineValidators([
+  validateUpdateIntervalMs,
+  validateColor
+])
 
 export const defaultOptions = {
+  updateIntervalMs: 60000,
   color: 'lightYellow'
 }

--- a/src/lib/utils/validators.js
+++ b/src/lib/utils/validators.js
@@ -1,0 +1,23 @@
+export const validateUpdateIntervalMs = (options) => {
+  const errors = []
+
+  if (typeof options.updateIntervalMs === 'undefined') {
+    errors.push('\'updateIntervalMs\' is required but missing.')
+  } else {
+    if (typeof options.updateIntervalMs !== 'number') {
+      errors.push('update interval must be defined as a number.')
+    } else {
+      if (options.updateIntervalMs < 1) {
+        errors.push('update interval must be at least 1ms.')
+      }
+    }
+  }
+
+  return errors
+}
+
+export const validateOptionsWith = (options, validators) => {
+  return validators
+    .map((validator) => validator(options))
+    .reduce((e1, e2) => e1.concat(e2), [])
+}

--- a/src/lib/utils/validators.js
+++ b/src/lib/utils/validators.js
@@ -1,3 +1,5 @@
+import { colorExists } from './colors'
+
 export const validateUpdateIntervalMs = (options) => {
   const errors = []
 
@@ -16,8 +18,26 @@ export const validateUpdateIntervalMs = (options) => {
   return errors
 }
 
-export const validateOptionsWith = (options, validators) => {
-  return validators
-    .map((validator) => validator(options))
-    .reduce((e1, e2) => e1.concat(e2), [])
+export const validateColor = (options) => {
+  let error
+
+  if (!options.color) {
+    error = '\'color\' color string is required but missing.'
+  } else if (!colorExists(options.color)) {
+    error = `invalid color '${options.color}'`
+  }
+
+  if (error === undefined) {
+    return []
+  } else {
+    return [ error ]
+  }
+}
+
+export const combineValidators = (validators) => {
+  return (options) => {
+    return validators
+      .map((validator) => validator(options))
+      .reduce((e1, e2) => e1.concat(e2), [])
+  }
 }


### PR DESCRIPTION
This resolves #36 🎉 

You can now configure the update interval for the plugins that update their data via polling (the hostname plugin does not update, and the battery plugin subscribes to change updates). Here is an example of how the CPU plugin can be configured:

```
...
{
  name: 'cpu',
  options: {
    colors: {
      high: "red",
      moderate: "yellow",
      low: "red"
    },
    updateIntervalMs: 1000
  }
}
```
