### PR TITLE
Improved .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,5 @@
-src/
+# All
+*
+
+# But not
+!dist/**


### PR DESCRIPTION
For test run `npm pack`.

Before:
```sh
$ tree -a
.
├── .babelrc
├── dist
│   └── hyperline.js
├── .editorconfig
├── .eslintrc
├── .npmignore
├── package.json
├── README.md
└── webpack.config.js

1 directory, 8 files
```

After:
```sh
$ tree -a
.
├── dist
│   └── hyperline.js
├── package.json
└── README.md

1 directory, 3 files
```

Now anything extra.