### PR TITLE
Show external IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ module.exports = {
           }
         },
         {
+          name: 'ip',
+          options: {
+            color: 'magenta'
+          }
+        },
+        {
           name: 'memory',
           options: {
             color: 'white'

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "color": "^0.11.3",
     "json-loader": "^0.5.4",
+    "public-ip": "^2.0.1",
     "systeminformation": "^3.4.1"
   }
 }

--- a/src/lib/plugins/index.js
+++ b/src/lib/plugins/index.js
@@ -1,4 +1,5 @@
 import * as hostname from './hostname'
+import * as ip from './ip'
 import * as memory from './memory'
 import * as uptime from './uptime'
 import * as cpu from './cpu'
@@ -9,4 +10,4 @@ import * as battery from './battery'
  * Exports a mapping from plugin name to associated component factory.
  * Object keys match those used in the configuration object
  */
-export default { hostname, memory, uptime, cpu, network, battery }
+export default { hostname, ip, memory, uptime, cpu, network, battery }

--- a/src/lib/plugins/ip.js
+++ b/src/lib/plugins/ip.js
@@ -1,0 +1,84 @@
+import publicIp from 'public-ip'
+import { iconStyles } from '../utils/icons'
+import { colorExists } from '../utils/colors'
+import pluginWrapperFactory from '../core/PluginWrapper'
+
+export function componentFactory(React, colors) {
+  const PluginIcon = ({ fillColor }) => (
+    <svg style={iconStyles} xmlns="http://www.w3.org/2000/svg">
+      <g fill="none" fillRule="evenodd">
+        <g fill={fillColor} transform="translate(1.000000, 1.000000)">
+          <path d="M9,9 L8,9 C8.55,9 9,8.55 9,8 L9,7 C9,6.45 8.55,6 8,6 L7,6 C6.45,6 6,6.45 6,7 L6,8 C6,8.55 6.45,9 7,9 L6,9 C5.45,9 5,9.45 5,10 L5,12 L6,12 L6,15 C6,15.55 6.45,16 7,16 L8,16 C8.55,16 9,15.55 9,15 L9,12 L10,12 L10,10 C10,9.45 9.55,9 9,9 L9,9 Z M7,7 L8,7 L8,8 L7,8 L7,7 L7,7 Z M9,11 L8,11 L8,15 L7,15 L7,11 L6,11 L6,10 L9,10 L9,11 L9,11 Z M11.09,7.5 C11.09,5.52 9.48,3.91 7.5,3.91 C5.52,3.91 3.91,5.52 3.91,7.5 C3.91,7.78 3.94,8.05 4,8.31 L4,10.29 C3.39,9.52 3,8.56 3,7.49 C3,5.01 5.02,2.99 7.5,2.99 C9.98,2.99 12,5.01 12,7.49 C12,8.55 11.61,9.52 11,10.29 L11,8.31 C11.06,8.04 11.09,7.78 11.09,7.5 L11.09,7.5 Z M15,7.5 C15,10.38 13.37,12.88 11,14.13 L11,13.08 C12.86,11.92 14.09,9.86 14.09,7.5 C14.09,3.86 11.14,0.91 7.5,0.91 C3.86,0.91 0.91,3.86 0.91,7.5 C0.91,9.86 2.14,11.92 4,13.08 L4,14.13 C1.63,12.88 0,10.38 0,7.5 C0,3.36 3.36,0 7.5,0 C11.64,0 15,3.36 15,7.5 L15,7.5 Z" id="Shape"></path>
+        </g>
+      </g>
+    </svg>
+  )
+
+  PluginIcon.propTypes = {
+    fillColor: React.PropTypes.string
+  }
+
+  return class extends React.Component {
+    static displayName() {
+      return 'IP Address plugin'
+    }
+
+    static propTypes() {
+      return {
+        options: React.PropTypes.object
+      }
+    }
+
+    constructor(props) {
+      super(props)
+
+      this.state = {ip: '?.?.?.?'}
+      publicIp.v4().then(ip => {
+        this.setState({ip: ip})
+      })
+    }
+
+    componentDidMount() {
+      this.interval = setInterval(() => (
+        publicIp.v4()
+        .then(ip => {
+          this.setState({ip: ip})
+        })
+        .catch(() => {
+          this.setState({ip: '?.?.?.?'})
+        })
+      ), 60000 * 5)
+    }
+
+    componentWillUnmount() {
+      clearInterval(this.interval)
+    }
+
+    render() {
+      const PluginWrapper = pluginWrapperFactory(React)
+      const fillColor = colors[this.props.options.color]
+
+      return (
+        <PluginWrapper color={fillColor}>
+          <PluginIcon fillColor={fillColor} /> {this.state.ip}
+        </PluginWrapper>
+      )
+    }
+  }
+}
+
+export const validateOptions = options => {
+  const errors = []
+
+  if (!options.color) {
+    errors.push('\'color\' color string is required but missing.')
+  } else if (!colorExists(options.color)) {
+    errors.push(`invalid color '${options.color}'`)
+  }
+
+  return errors
+}
+
+export const defaultOptions = {
+  color: 'magenta'
+}


### PR DESCRIPTION
This adds your external IP address to `hyperline`. I chose the [`broadcast` icon](https://octicons.github.com/icon/broadcast/) from Octicons. I chose `magenta` because it wasn't being used yet. The interval is every 5 mins, which might be too frequent for other people's liking. I don't know if we prefer to offer a setting or just hardcode something less frequent (1 hour?)

### IP Known

![screen shot 2016-12-06 at 1 18 38 am](https://cloud.githubusercontent.com/assets/737065/20915235/7e0bc948-bb52-11e6-9753-b92d133af6ab.png)

### IP Unknown

![screen shot 2016-12-06 at 1 19 35 am](https://cloud.githubusercontent.com/assets/737065/20915236/7e0bf9f4-bb52-11e6-81a3-005340065f57.png)
