### PR TITLE
Fix uptime : setInterval leak

### DIFF
--- a/src/lib/plugins/uptime.js
+++ b/src/lib/plugins/uptime.js
@@ -38,9 +38,13 @@ export function componentFactory(React, colors) {
 
     componentDidMount() {
       // Recheck every 5 minutes
-      setInterval(() => ({
+      this.interval = setInterval(() => ({
         uptime: this.setState(this.getUptime())
       }), 60000 * 5)
+    }
+
+    componentWillUnmount() {
+      clearInterval(this.interval)
     }
 
     getUptime() {


### PR DESCRIPTION
setInterval was never cleared. After a lot of unmounting, there was a lot of error 
![capture d ecran 2016-12-31 a 10 51 09](https://cloud.githubusercontent.com/assets/4137761/21576945/20122a22-cf47-11e6-9858-9ca9ea61af2a.png)

(other setInterval has been checked)